### PR TITLE
Updated dependencies, added typeRoots to utilize @types properly

### DIFF
--- a/app/hello-world.component.ngfactory.ts
+++ b/app/hello-world.component.ngfactory.ts
@@ -62,8 +62,8 @@ class _View_HelloWorldComponent0 extends import3.DebugAppView<import1.HelloWorld
   createInternal(rootSelector:string):import4.AppElement {
     const parentRenderNode:any = this.renderer.createViewRoot(this.declarationAppElement.nativeElement);
     this._el_0 = this.renderer.createElement(parentRenderNode,'h1',this.debug(0,0,0));
-    this._text_1 = this.renderer.createText(this._el_0,'Hello World!',this.debug(1,0,4));
-    this._text_2 = this.renderer.createText(parentRenderNode,'\n',this.debug(2,0,21));
+    this._text_1 = this.renderer.createText(this._el_0,'Hello World!!!',this.debug(1,0,4));
+    this._text_2 = this.renderer.createText(parentRenderNode,'\n',this.debug(2,0,23));
     this.init(([] as any[]),[
       this._el_0,
       this._text_1,
@@ -74,6 +74,6 @@ class _View_HelloWorldComponent0 extends import3.DebugAppView<import1.HelloWorld
   }
 }
 export function viewFactory_HelloWorldComponent0(viewUtils:import5.ViewUtils,parentInjector:import6.Injector,declarationEl:import4.AppElement):import3.AppView<import1.HelloWorldComponent> {
-  if ((renderType_HelloWorldComponent === (null as any))) { (renderType_HelloWorldComponent = viewUtils.createRenderComponentType('C:/Users/bernting/Source/Repos/angular2-aot-webpack-new/app/hello-world.template.html',0,import9.ViewEncapsulation.None,styles_HelloWorldComponent,{})); }
+  if ((renderType_HelloWorldComponent === (null as any))) { (renderType_HelloWorldComponent = viewUtils.createRenderComponentType('C:/Users/bernting/Source/Repos/angular2-aot-webpack/app/hello-world.template.html',0,import9.ViewEncapsulation.None,styles_HelloWorldComponent,{})); }
   return new _View_HelloWorldComponent0(viewUtils,parentInjector,declarationEl);
 }

--- a/app/hello-world.component.ngfactory.ts
+++ b/app/hello-world.component.ngfactory.ts
@@ -29,9 +29,9 @@ class _View_HelloWorldComponent_Host0 extends import3.DebugAppView<any> {
     this._appEl_0 = new import4.AppElement(0,(null as any),this,this._el_0);
     var compView_0:any = viewFactory_HelloWorldComponent0(this.viewUtils,this.injector(0),this._appEl_0);
     this._HelloWorldComponent_0_4 = new import1.HelloWorldComponent();
-    this._appEl_0.initComponent(this._HelloWorldComponent_0_4,[],compView_0);
+    this._appEl_0.initComponent(this._HelloWorldComponent_0_4,([] as any[]),compView_0);
     compView_0.create(this._HelloWorldComponent_0_4,this.projectableNodes,(null as any));
-    this.init([].concat([this._el_0]),[this._el_0],[],[]);
+    this.init(([] as any[]).concat([this._el_0]),[this._el_0],([] as any[]),([] as any[]));
     return this._appEl_0;
   }
   injectorGetInternal(token:any,requestNodeIndex:number,notFoundResult:any):any {
@@ -40,15 +40,15 @@ class _View_HelloWorldComponent_Host0 extends import3.DebugAppView<any> {
   }
 }
 function viewFactory_HelloWorldComponent_Host0(viewUtils:import5.ViewUtils,parentInjector:import6.Injector,declarationEl:import4.AppElement):import3.AppView<any> {
-  if ((renderType_HelloWorldComponent_Host === (null as any))) { (renderType_HelloWorldComponent_Host = viewUtils.createRenderComponentType('',0,import9.ViewEncapsulation.None,[],{})); }
+  if ((renderType_HelloWorldComponent_Host === (null as any))) { (renderType_HelloWorldComponent_Host = viewUtils.createRenderComponentType('',0,import9.ViewEncapsulation.None,([] as any[]),{})); }
   return new _View_HelloWorldComponent_Host0(viewUtils,parentInjector,declarationEl);
 }
 export const HelloWorldComponentNgFactory:import10.ComponentFactory<import1.HelloWorldComponent> = new import10.ComponentFactory<import1.HelloWorldComponent>('hello-world-app',viewFactory_HelloWorldComponent_Host0,import1.HelloWorldComponent);
-const styles_HelloWorldComponent:any[] = [];
+const styles_HelloWorldComponent:any[] = ([] as any[]);
 const nodeDebugInfos_HelloWorldComponent0:import0.StaticNodeDebugInfo[] = [
-  new import0.StaticNodeDebugInfo([],(null as any),{}),
-  new import0.StaticNodeDebugInfo([],(null as any),{}),
-  new import0.StaticNodeDebugInfo([],(null as any),{})
+  new import0.StaticNodeDebugInfo(([] as any[]),(null as any),{}),
+  new import0.StaticNodeDebugInfo(([] as any[]),(null as any),{}),
+  new import0.StaticNodeDebugInfo(([] as any[]),(null as any),{})
 ]
 ;
 var renderType_HelloWorldComponent:import2.RenderComponentType = (null as any);
@@ -64,16 +64,16 @@ class _View_HelloWorldComponent0 extends import3.DebugAppView<import1.HelloWorld
     this._el_0 = this.renderer.createElement(parentRenderNode,'h1',this.debug(0,0,0));
     this._text_1 = this.renderer.createText(this._el_0,'Hello World!',this.debug(1,0,4));
     this._text_2 = this.renderer.createText(parentRenderNode,'\n',this.debug(2,0,21));
-    this.init([],[
+    this.init(([] as any[]),[
       this._el_0,
       this._text_1,
       this._text_2
     ]
-    ,[],[]);
+    ,([] as any[]),([] as any[]));
     return (null as any);
   }
 }
 export function viewFactory_HelloWorldComponent0(viewUtils:import5.ViewUtils,parentInjector:import6.Injector,declarationEl:import4.AppElement):import3.AppView<import1.HelloWorldComponent> {
-  if ((renderType_HelloWorldComponent === (null as any))) { (renderType_HelloWorldComponent = viewUtils.createRenderComponentType('/home/blacksonic/workspace/ng2-aot/app/hello-world.template.html',0,import9.ViewEncapsulation.None,styles_HelloWorldComponent,{})); }
+  if ((renderType_HelloWorldComponent === (null as any))) { (renderType_HelloWorldComponent = viewUtils.createRenderComponentType('C:/Users/bernting/Source/Repos/angular2-aot-webpack-new/app/hello-world.template.html',0,import9.ViewEncapsulation.None,styles_HelloWorldComponent,{})); }
   return new _View_HelloWorldComponent0(viewUtils,parentInjector,declarationEl);
 }

--- a/app/hello-world.component.ts
+++ b/app/hello-world.component.ts
@@ -4,4 +4,4 @@ import { Component } from '@angular/core';
   selector: 'hello-world-app',
   templateUrl: 'hello-world.template.html'
 })
-export class HelloWorldComponent {}
+export class HelloWorldComponent { private cooltest: any; }

--- a/app/hello-world.component.ts
+++ b/app/hello-world.component.ts
@@ -4,4 +4,4 @@ import { Component } from '@angular/core';
   selector: 'hello-world-app',
   templateUrl: 'hello-world.template.html'
 })
-export class HelloWorldComponent { private cooltest: any; }
+export class HelloWorldComponent { }

--- a/app/hello-world.template.html
+++ b/app/hello-world.template.html
@@ -1,1 +1,1 @@
-<h1>Hello World!!!</h1>
+<h1>Hello World!</h1>

--- a/app/hello-world.template.html
+++ b/app/hello-world.template.html
@@ -1,1 +1,1 @@
-<h1>Hello World!</h1>
+<h1>Hello World!!!</h1>

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@angular/platform-browser": "^2.0.1",
     "@angular/platform-browser-dynamic": "^2.0.1",
     "@angular/platform-server": "^2.0.1",
-    "@ngtools/webpack": "^1.0.0",
+    "@ngtools/webpack": "^1.1.0",
     "@types/core-js": "^0.9.34",
     "@types/node": "^6.0.41",
     "angular2-template-loader": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@angular/common": "^2.0.1",
     "@angular/compiler": "^2.0.1",
-    "@angular/compiler-cli": "^0.6.3",
+    "@angular/compiler-cli": "^2.1.0",
     "@angular/core": "^2.0.1",
     "@angular/platform-browser": "^2.0.1",
     "@angular/platform-browser-dynamic": "^2.0.1",
@@ -44,7 +44,7 @@
     "http-server": "^0.9.0",
     "raw-loader": "^0.5.1",
     "rxjs": "^5.0.0-beta.12",
-    "typescript": "2.0.2",
+    "typescript": "2.0.3",
     "webpack": "^2.1.0-beta.25",
     "zone.js": "^0.6.25"
   }

--- a/tsconfig.aot.json
+++ b/tsconfig.aot.json
@@ -23,11 +23,12 @@
     ]
   },
   "angularCompilerOptions": {
-    "debug": true
+    "debug": true,
+    "skipMetadataEmit": true
   },
   "compileOnSave": false,
   "files": [
-    "app/main.ts"
+    "app/bootstrap.aot.ts"
   ],
   "exclude": [
     "node_modules",

--- a/tsconfig.aot.json
+++ b/tsconfig.aot.json
@@ -17,6 +17,7 @@
     "noFallthroughCasesInSwitch": true,
     "outDir": "./dist",
     "rootDir": "./app",
+    "typeRoots": [ "./node_modules/@types" ],
     "types": [
       "node"
     ]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "sourceMap": true,
+    "typeRoots": [ "./node_modules/@types" ],
     "types": [
       "core-js",
       "node"

--- a/webpack.aot.config.js
+++ b/webpack.aot.config.js
@@ -30,8 +30,8 @@ module.exports = {
   },
 
   plugins: [
-    new ngtools.NgcWebpackPlugin({
-      project: './tsconfig.aot.json',
+    new ngtools.AotPlugin({
+      tsConfigPath: './tsconfig.aot.json',
       baseDir: path.resolve(__dirname, ''),
       entryModule: path.join(__dirname, 'app', 'main') + '#MainModule'
     }),

--- a/webpack.aot.config.js
+++ b/webpack.aot.config.js
@@ -18,8 +18,7 @@ module.exports = {
       {
         test: /\.ts$/,
         use: [
-          'awesome-typescript?tsconfig=tsconfig.json',
-          'angular2-template'
+          "@ngtools/webpack"
         ]
       },
       {


### PR DESCRIPTION
It seems `AotPlugin` is not generating ngfactories right now..

I updated the dependencies, but in the end I have to run `ngc -p tsconfig.aot.json` now to generate the factories.

Another note is that AotPlugin seems to not work well with watch mode in Webpack right now (modifying html files), but that may be just because ngfactories are not working properly.
